### PR TITLE
Update import statements and SDK version

### DIFF
--- a/src/electrifier/Services/ActivationService.cs
+++ b/src/electrifier/Services/ActivationService.cs
@@ -2,8 +2,9 @@
 using electrifier.Contracts.Services;
 using electrifier.Helpers;
 using electrifier.Views;
-using Microsoft.UI.Xaml.Controls;
+
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace electrifier.Services;
 

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -32,14 +32,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
+    <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.1.240328-rc" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.1.240328-rc" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.1.240328-rc" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240328-rc" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240328-rc" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.3.24172.9" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Vanara.Windows.Shell" Version="4.0.1" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Vanara.Windows.Shell" Version="4.0.1" />
     <PackageReference Include="WinUIEdit" Version="0.0.3-prerelease" />


### PR DESCRIPTION
In `ActivationService.cs`, the import statement for `Microsoft.UI.Xaml.Controls` was removed and then added back in. A new import statement for `Microsoft.UI.Xaml` was also added. In `electrifier.csproj`, the version of `Microsoft.WindowsAppSDK` was updated from `1.5.240404000` to `1.5.240428000`.