### PR TITLE
Update SDKs to current versions

### DIFF
--- a/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml
@@ -47,7 +47,7 @@
             <Button x:Uid="ReloadButton">
                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;" />
             </Button>
-            <controls:GridSplitter />
+            <Border /><!-- controls:GridSplitter -->
             <CommandBar
                 x:Name="TopCommandBar"
                 Grid.Row="0"
@@ -255,18 +255,7 @@
                 <local:Shell32TreeView x:Name="ShellTreeView" />
             </Border>
             <!--  TODO: GridSplitter is not Working when TreeView Visibility changes to Collapsed  -->
-            <controls:GridSplitter
-                x:Name="ArenaGridSplitter"
-                Grid.Column="1"
-                Width="12"
-                HorizontalAlignment="Left"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns"
-                Visibility="{x:Bind ArenaGridSplitterVisibility}">
-                <controls:GridSplitter.RenderTransform>
-                    <TranslateTransform X="-6" />
-                </controls:GridSplitter.RenderTransform>
-            </controls:GridSplitter>
+            <Border Grid.Column="1"  /><!-- controls:GridSplitter -->
             <Border x:Name="ShellGridViewBorder" Grid.Column="2">
                 <StackPanel Orientation="Vertical">
                     <local:Shell32GridView

--- a/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
@@ -158,11 +158,6 @@ public sealed partial class ExplorerBrowser : INotifyPropertyChanged
         get; set;
     }
 
-    public Visibility ArenaGridSplitterVisibility =>
-        ((TreeViewVisibility == Visibility.Visible) && (GridViewVisibility == Visibility.Visible))
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-
     public ICommand RefreshViewCommand
     {
         get;

--- a/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml;

--- a/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowser.xaml.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.WinUI.UI;
+using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml;
@@ -122,11 +122,6 @@ public sealed partial class ExplorerBrowser : INotifyPropertyChanged
         }
     }
 
-    public ImageCache? ImageCache
-    {
-        get; set;
-    }
-
     public bool IsLoading
     {
         get; set;
@@ -195,7 +190,6 @@ public sealed partial class ExplorerBrowser : INotifyPropertyChanged
         InitializeComponent();
         DataContext = this;
 
-        ImageCache = new ImageCache();
         CurrentFolderItems = [];
         CurrentFolderBrowserItem = new ExplorerBrowserItem(ShellFolder.Desktop);
         RefreshViewCommand = new RelayCommand(() => OnRefreshViewCommand(this, new RoutedEventArgs()));

--- a/src/electrifier/Controls/Vanara/ExplorerBrowserItem.cs
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowserItem.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using System.ComponentModel;
-using CommunityToolkit.WinUI.UI.Controls;
+using CommunityToolkit.WinUI.Controls;
 
 namespace electrifier.Controls.Vanara;
 
@@ -48,11 +48,6 @@ public class ExplorerBrowserItem /* : INotifyPropertyChanged */
             }
             return false;
         }
-    }
-    public ImageEx? ImageIconSource
-    {
-        get;
-        internal set;
     }
     public bool IsExpanded
     {

--- a/src/electrifier/Controls/Vanara/ExplorerBrowserItem.cs
+++ b/src/electrifier/Controls/Vanara/ExplorerBrowserItem.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using System.ComponentModel;
-using CommunityToolkit.WinUI.Controls;
 
 namespace electrifier.Controls.Vanara;
 

--- a/src/electrifier/Controls/Vanara/Shell32GridView.xaml
+++ b/src/electrifier/Controls/Vanara/Shell32GridView.xaml
@@ -3,7 +3,7 @@
     x:Class="electrifier.Controls.Vanara.Shell32GridView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:electrifier.Controls.Vanara"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -17,14 +17,11 @@
                         Width="72"
                         Height="96"
                         Orientation="Vertical">
-                        <controls:ImageEx
-                            Name="ImageEx"
-                            DecodePixelHeight="64"
-                            DecodePixelType="Physical"
-                            EnableLazyLoading="True"
-                            IsCacheEnabled="True"
-                            PlaceholderSource="ms-appx:///Assets/Views/Workbench/Shell32 Default unknown File_64x64-32.png"
-                            Source="{x:Bind ImageIconSource}" />
+                        <Image
+                            Name="Image"
+                            Height="48"
+                            Source="ms-appx:///Assets/Views/Workbench/Shell32 Default unknown File_64x64-32.png" />
+                        <!--  Source="{x:Bind ImageIconSource}" -->
                         <!--  ImageExOpened="ImageEx_ImageExOpened"  -->
                         <!--  CornerRadius="8"  -->
                         <TextBlock

--- a/src/electrifier/Controls/Vanara/Shell32TreeView.xaml
+++ b/src/electrifier/Controls/Vanara/Shell32TreeView.xaml
@@ -3,7 +3,7 @@
     x:Class="electrifier.Controls.Vanara.Shell32TreeView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:electrifier.Controls.Vanara"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -20,13 +20,10 @@
                         IsSelected="{x:Bind IsSelected}"
                         ItemsSource="{x:Bind Children}">
                         <StackPanel MaxHeight="20" Orientation="Horizontal">
-                            <controls:ImageEx
+                            <Image
                                 Name="ExplorerBrowserItemImageEx"
-                                DecodePixelType="Physical"
-                                EnableLazyLoading="True"
-                                IsCacheEnabled="True"
-                                PlaceholderSource="ms-appx:///Assets/Views/Workbench/Shell32 Default Folder_16x16-32.png"
-                                Source="{x:Bind ImageIconSource}" />
+                                Source="ms-appx:///Assets/Views/Workbench/Shell32 Default Folder_16x16-32.png"/>
+                            <!--  Source="{x:Bind ImageIconSource}" -->
                             <TextBlock
                                 x:Name="ExplorerBrowserItemDisplayNameTextBlock"
                                 Margin="5,0,5,0"

--- a/src/electrifier/Services/NavigationService.cs
+++ b/src/electrifier/Services/NavigationService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using CommunityToolkit.WinUI.UI.Animations;
+using CommunityToolkit.WinUI.Animations;
 using electrifier.Contracts.Services;
 using electrifier.Contracts.ViewModels;
 using electrifier.Helpers;

--- a/src/electrifier/Views/KanbanBoardDetailPage.xaml.cs
+++ b/src/electrifier/Views/KanbanBoardDetailPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.WinUI.UI.Animations;
+﻿using CommunityToolkit.WinUI.Animations;
 using electrifier.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;

--- a/src/electrifier/Views/KanbanBoardPage.xaml
+++ b/src/electrifier/Views/KanbanBoardPage.xaml
@@ -2,7 +2,7 @@
     x:Class="electrifier.Views.KanbanBoardPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/electrifier/Views/KanbanBoardPage.xaml
+++ b/src/electrifier/Views/KanbanBoardPage.xaml
@@ -3,14 +3,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="using:electrifier.ViewModels"
     d:DataContext="{d:DesignInstance Type=viewmodels:KanbanBoardViewModel}"
     mc:Ignorable="d">
     <Grid x:Name="ContentArea">
-        <controls:AdaptiveGridView
+        <!--<controls:AdaptiveGridView
             animations:Connected.ListItemElementName="itemThumbnail"
             animations:Connected.ListItemKey="animationKeyContentGrid"
             DesiredWidth="180"
@@ -19,7 +19,7 @@
             ItemHeight="160"
             SelectionMode="None"
             StretchContentForSingleRow="False">
-            <!--  ItemsSource="{x:Bind ViewModel.Source,Mode=OneWay}"  -->
+            --><!--  ItemsSource="{x:Bind ViewModel.Source,Mode=OneWay}"  -->
             <!--<controls:AdaptiveGridView.ItemTemplate>
                 <DataTemplate x:DataType="models:SampleOrder">
                     <Grid
@@ -37,7 +37,7 @@
                         </StackPanel>
                     </Grid>
                 </DataTemplate>
-            </controls:AdaptiveGridView.ItemTemplate>-->
-        </controls:AdaptiveGridView>
+            </controls:AdaptiveGridView.ItemTemplate>--><!--
+        </controls:AdaptiveGridView>-->
     </Grid>
 </Page>

--- a/src/electrifier/Views/TextEditorPage.xaml
+++ b/src/electrifier/Views/TextEditorPage.xaml
@@ -62,17 +62,7 @@
                     GridViewVisibility="Collapsed"
                     TopCommandBarVisibility="Collapsed" />
             </Border>
-            <controls:GridSplitter
-                x:Name="GridSplitter"
-                Grid.Column="1"
-                Width="12"
-                HorizontalAlignment="Left"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns">
-                <controls:GridSplitter.RenderTransform>
-                    <TranslateTransform X="-6" />
-                </controls:GridSplitter.RenderTransform>
-            </controls:GridSplitter>
+            <Border Grid.Column="1"/><!-- controls:GridSplitter -->
             <Border x:Name="CodeEditorBorder" Grid.Column="2">
                 <editor:CodeEditorControl x:Name="CodeEditorControl" />
             </Border>

--- a/src/electrifier/Views/WorkbenchPage.xaml
+++ b/src/electrifier/Views/WorkbenchPage.xaml
@@ -74,16 +74,7 @@
                 <ItemsStackPanel />
             </Grid>
         </Border>
-        <controls:GridSplitter
-            Grid.Column="1"
-            Width="12"
-            HorizontalAlignment="Left"
-            ResizeBehavior="BasedOnAlignment"
-            ResizeDirection="Columns">
-            <controls:GridSplitter.RenderTransform>
-                <TranslateTransform X="-6" />
-            </controls:GridSplitter.RenderTransform>
-        </controls:GridSplitter>
+        <Border /><!-- controls:GridSplitter -->
         <StackPanel x:Name="SidebarStackPanel" Grid.Column="2">
             <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="SideBar" />
             <InfoBar

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <LangVersion>12.0</LangVersion>
     <RootNamespace>electrifier</RootNamespace>
@@ -36,12 +36,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240916" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -36,12 +36,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Vanara.Windows.Shell" Version="4.0.4" />
     <PackageReference Include="Vanara.Windows.Shell.Common" Version="4.0.4" />
     <PackageReference Include="WinUIEdit" Version="0.0.3-prerelease" />
-    <PackageReference Include="WinUIEx" Version="2.3.4" />
+    <PackageReference Include="WinUIEx" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/electrifier/electrifier.csproj
+++ b/src/electrifier/electrifier.csproj
@@ -42,8 +42,8 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
- Remove `GridSplitter` from XAMLs
- Remove `ImageCache` from ExplorerBrowser
- Remove `ImageEx` from Shell32GridView
- Remove using `CommunityToolkit.WinUI.UI.Controls` and `CommunityToolkit.WinUI.UI.Animations` (deprecated)
- Update TargetFrameWork to `net7.0-windows10.0.22621.0` in Order to Upgrade CommunityToolkit Packages from 7 to 8